### PR TITLE
Fix dimensions in DASonicFoam equations

### DIFF
--- a/Cylinder/0_orig/p
+++ b/Cylinder/0_orig/p
@@ -15,9 +15,9 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-dimensions      [0 2 -2 0 0 0 0];
+dimensions      [1 -1 -2 0 0 0 0];
 
-internalField   uniform 0;
+internalField   uniform 101325;
 
 boundaryField
 {

--- a/src/adjoint/DASolver/DASonicFoam/EEqnSonic.H
+++ b/src/adjoint/DASolver/DASonicFoam/EEqnSonic.H
@@ -2,14 +2,13 @@
     // Calculate energy source term if actuator disk is present
     if (hasFvSource_)
     {
-        // fvSource stores acceleration (force per unit mass). Convert it to
-        // power per unit volume for the energy equation by multiplying with
-        // the local density before taking the inner product with velocity.
-        fvSourceEnergy = (rho * fvSource) & U;
+        // fvSource is defined as force per unit volume; its dot product with
+        // velocity gives the power input per unit volume
+        fvSourceEnergy = fvSource & U;
     }
 
     // Sync thermo's T with our T field before energy equation
-// Access thermo.he() directly
+    // Access thermo.he() directly
     volScalarField& e = thermo.he();
 
     fvScalarMatrix EEqn(
@@ -22,7 +21,8 @@
           : -dpdt)
       - fvm::laplacian(turbulencePtr_->alphaEff(), e)
       - fvSourceEnergy
-);EEqn.relax();
+    );
+    EEqn.relax();
 
     SolverPerformance<scalar> solverE = EEqn.solve();
 
@@ -33,6 +33,6 @@
 
     // Update thermodynamic properties
     thermo.correct();
-    
+
     // After thermo correction, update our T field to match thermo's T
 }

--- a/src/adjoint/DASolver/DASonicFoam/UEqnSonic.H
+++ b/src/adjoint/DASolver/DASonicFoam/UEqnSonic.H
@@ -1,33 +1,37 @@
 // Solve the Momentum equation
 
-// MRF.correctBoundaryVelocity(U);   // MRF is not used 
+// MRF.correctBoundaryVelocity(U);   // MRF is not used
 if (hasFvSource_)
 {
     daFvSourcePtr_->calcFvSource(fvSource);
 }
 
-
+// Build the conventional momentum equation. The body-force fvSource will be
+// added explicitly via the source term below.
 tmp<fvVectorMatrix> tUEqn(
-    // Build the conventional momentum equation. The body-force fvSource is
-    // supplied in acceleration units (force per unit mass), so convert it to
-    // a force per unit volume by multiplying with rho before adding it to
-    // the equation.
     fvm::ddt(rho, U)
-    + fvm::div(phi, U)
-    + daTurbulenceModelPtr_->divDevRhoReff(U)
-    - rho*fvSource);
+  + fvm::div(phi, U)
+  + daTurbulenceModelPtr_->divDevRhoReff(U));
 fvVectorMatrix& UEqn = tUEqn.ref();
+
+// Add external body-force source term explicitly to the equation source
+if (hasFvSource_)
+{
+    UEqn.source() -= fvSource;
+}
 
 UEqn.relax();
 
-// get the solver performance info such as initial
-// and final residuals
-// Solve the momentum equation
+// Apply any fvOptions constraints after relaxation
+fvOptions.constrain(UEqn);
+
+// Solve the momentum equation and retrieve solver performance
 SolverPerformance<vector> solverU = solve(UEqn == -fvc::grad(p));
 
+// Apply any fvOptions corrections to the solved field
+fvOptions.correct(U);
+
 DAUtility::primalResidualControl(solverU, pimplePrintToScreen, "U", daGlobalVarPtr_->primalMaxRes);
- 
-								 
 
 // bound U
 DAUtility::boundVar(allOptions, U, pimplePrintToScreen);

--- a/src/adjoint/DASolver/DASonicFoam/createFieldsSonic.H
+++ b/src/adjoint/DASolver/DASonicFoam/createFieldsSonic.H
@@ -64,10 +64,9 @@ fvSourcePtr_.reset(
         mesh,
         dimensionedVector(
             "fvSource",
-            // fvSource represents a body-force per unit mass (acceleration)
-            // and is added directly to the momentum equation without
-            // additional scaling
-            dimensionSet(0, 1, -2, 0, 0, 0, 0),
+            // fvSource represents a body force per unit volume and is added
+            // explicitly to the momentum equation
+            dimensionSet(1, -2, -2, 0, 0, 0, 0),
             vector::zero)));
 
 fvSourceEnergyPtr_.reset(

--- a/src/adjoint/DASolver/DASonicFoam/pEqnSonic.H
+++ b/src/adjoint/DASolver/DASonicFoam/pEqnSonic.H
@@ -1,18 +1,18 @@
+rho = thermo.rho();
+
 volScalarField rAU(1.0/UEqn.A());
+surfaceScalarField rhorAUf("rhorAUf", fvc::interpolate(rho*rAU));
 volVectorField HbyA("HbyA", U);
 HbyA = rAU*UEqn.H();
-
-surfaceScalarField phiHbyA
-(
-    "phiHbyA",
-    fvc::flux(rho*HbyA)
-);
 
 surfaceScalarField phid
 (
     "phid",
     fvc::interpolate(psi)
-    * phiHbyA
+   * (
+        fvc::flux(HbyA)
+      + rhorAUf * fvc::ddtCorr(rho, U, phi) / fvc::interpolate(rho)
+     )
 );
 
 // Non-orthogonal pressure corrector loop
@@ -21,13 +21,9 @@ while (pimple.correctNonOrthogonal())
     fvScalarMatrix pEqn
     (
         fvm::ddt(psi, p)
-        + fvm::div(phid, p)
-        // The momentum equation is formulated in terms of acceleration
-        // (pressure gradient divided by density). Consequently the
-        // pressure correction uses rAU alone instead of rho*rAU to keep
-        // the units consistent
-        - fvm::laplacian(rAU, p)
-        ==
+      + fvm::div(phid, p)
+      - fvm::laplacian(rhorAUf, p)
+     ==
         fvOptions(psi, p, rho.name())
     );
 
@@ -35,25 +31,17 @@ while (pimple.correctNonOrthogonal())
 
     if (pimple.finalNonOrthogonalIter())
     {
-        // Combine the predicted flux with the pressure correction flux
-        // to maintain a mass flux phi for consistent momentum coupling
-        phi = phiHbyA + pEqn.flux();
+        phi = pEqn.flux();
     }
 }
 
 #include "rhoEqn.H"
 #include "compressibleContinuityErrs.H"
 
-// Update velocity and kinetic energy
-// Scale the pressure gradient by rho to obtain acceleration before
-// applying the rAU operator
-U = HbyA - rAU*(fvc::grad(p)/rho);
+U = HbyA - rAU*fvc::grad(p);
 U.correctBoundaryConditions();
 fvOptions.correct(U);
 K = 0.5*magSqr(U);
 
-// Update density from equation of state
 rho = thermo.rho();
-
-// Bound density if needed
 DAUtility::boundVar(allOptions, rho, pimplePrintToScreen);


### PR DESCRIPTION
## Summary
- Ensure actuator source term uses force-per-volume units
- Rebuild momentum equation with explicit body-force and fvOptions
- Update energy and pressure equations for consistent dimensions
- Apply body-force source via `UEqn.source()` to maintain dimensional consistency
- Use absolute pressure in Cylinder tutorial case to match compressible solver

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a38df16db0832aa77b985c87df0fe6