### PR TITLE
Fix rho field dimensions in DASonicFoam

### DIFF
--- a/src/adjoint/DASolver/DASonicFoam/createFieldsSonic.H
+++ b/src/adjoint/DASolver/DASonicFoam/createFieldsSonic.H
@@ -41,7 +41,15 @@ rhoPtr_.reset(
             mesh,
             IOobject::NO_READ,
             IOobject::AUTO_WRITE),
-        thermo.rho()));
+        // thermo.rho() in sonicFoam may return a field without mass-density
+        // dimensions, which later causes dimension mismatches when forming
+        // dynamic diffusivity terms like rho*alphat. Attach the correct
+        // density dimensions while preserving the numerical values.
+        thermo.rho()
+        * dimensionedScalar(
+              "rhoDim",
+              dimensionSet(1, -3, 0, 0, 0, 0, 0),
+              1.0)));
 volScalarField& rho = rhoPtr_();
 
 // Sync thermo's T with our T field

--- a/src/adjoint/DASolver/DASonicFoam/pEqnSonic.H
+++ b/src/adjoint/DASolver/DASonicFoam/pEqnSonic.H
@@ -1,4 +1,10 @@
-rho = thermo.rho();
+// thermo.rho() may lack mass-density dimensions; reattach them to avoid
+// dimension-set inconsistencies in subsequent operations.
+rho = thermo.rho()
+    * dimensionedScalar(
+          "rhoDim",
+          dimensionSet(1, -3, 0, 0, 0, 0, 0),
+          1.0);
 
 volScalarField rAU(1.0/UEqn.A());
 surfaceScalarField rhorAUf("rhorAUf", fvc::interpolate(rho*rAU));
@@ -43,5 +49,10 @@ U.correctBoundaryConditions();
 fvOptions.correct(U);
 K = 0.5*magSqr(U);
 
-rho = thermo.rho();
+// Keep rho field's physical dimensions consistent after each update
+rho = thermo.rho()
+    * dimensionedScalar(
+          "rhoDim",
+          dimensionSet(1, -3, 0, 0, 0, 0, 0),
+          1.0);
 DAUtility::boundVar(allOptions, rho, pimplePrintToScreen);


### PR DESCRIPTION
## Summary
- Ensure density field carries mass-density dimensions when created
- Preserve rho dimensions after updates in sonic pressure loop to avoid dimension mismatches

## Testing
- `python3 Cylinder/runScript.py -task run_model -optimizer IPOPT` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*
- `wmake src/adjoint` *(fails: command not found: wmake)*


------
https://chatgpt.com/codex/tasks/task_e_68b32290ba88832aad5f22ae2b8d202b