### PR TITLE
Fix rho and alphaEff dimension handling in DASonicFoam

### DIFF
--- a/src/adjoint/DAModel/DATurbulenceModel/DATurbulenceModel.C
+++ b/src/adjoint/DAModel/DATurbulenceModel/DATurbulenceModel.C
@@ -254,13 +254,19 @@ tmp<volScalarField> DATurbulenceModel::alphaEff()
     }
     else if (turbModelType_ == "compressible")
     {
-        const volScalarField& alphat = mesh_.thisDb().lookupObject<volScalarField>("alphat");
-        const volScalarField& rho = mesh_.thisDb().lookupObject<volScalarField>("rho");
-        const fluidThermo& thermo = mesh_.thisDb().lookupObject<fluidThermo>("thermophysicalProperties");
+        const volScalarField& alphat =
+            mesh_.thisDb().lookupObject<volScalarField>("alphat");
+        const fluidThermo& thermo =
+            mesh_.thisDb().lookupObject<fluidThermo>("thermophysicalProperties");
         return tmp<volScalarField>(
             new volScalarField(
                 "alphaEff",
-                thermo.alphaEff(rho * alphat)));
+                // For compressible flows thermo::alphaEff expects a
+                // kinematic turbulent diffusivity.  Supplying rho*alphat
+                // gives it dynamic viscosity units and leads to dimension
+                // mismatches.  Pass alphat directly so thermo handles the
+                // conversion internally.
+                thermo.alphaEff(alphat)));
     }
     else
     {

--- a/src/adjoint/DAResidual/DAResidualRhoPimpleFoam.C
+++ b/src/adjoint/DAResidual/DAResidualRhoPimpleFoam.C
@@ -144,7 +144,7 @@ void DAResidualRhoPimpleFoam::calcResiduals(const dictionary& options)
 
     // ******** e Residuals **********
     // copied and modified from EEqn.H
-    volScalarField alphaEff("alphaEff", thermo_.alphaEff(rho_ * alphat_));
+    volScalarField alphaEff("alphaEff", thermo_.alphaEff(alphat_));
 
     K_ = 0.5 * magSqr(U_);
     dpdt_ = fvc::ddt(p_);
@@ -413,7 +413,7 @@ void DAResidualRhoPimpleFoam::calcPCMatWithFvMatrix(Mat PCMat)
     // NOTE: the PCMatFVMatrix calculation for the EEqn is somehow way off
     // so we comment it out for now...
     // ******** e Residuals **********
-    volScalarField alphaEff("alphaEff", thermo_.alphaEff(rho_ * alphat_));
+    volScalarField alphaEff("alphaEff", thermo_.alphaEff(alphat_));
 
     K_ = 0.5 * magSqr(U_);
     dpdt_ = fvc::ddt(p_);

--- a/src/adjoint/DAResidual/DAResidualRhoSimpleCFoam.C
+++ b/src/adjoint/DAResidual/DAResidualRhoSimpleCFoam.C
@@ -125,7 +125,7 @@ void DAResidualRhoSimpleCFoam::calcResiduals(const dictionary& options)
 
     // ******** e Residuals **********
     // copied and modified from EEqn.H
-    volScalarField alphaEff("alphaEff", thermo_.alphaEff(rho_ * alphat_));
+    volScalarField alphaEff("alphaEff", thermo_.alphaEff(alphat_));
 
     fvScalarMatrix EEqn(
         fvm::div(phi_, he_, divHEScheme)

--- a/src/adjoint/DAResidual/DAResidualRhoSimpleFoam.C
+++ b/src/adjoint/DAResidual/DAResidualRhoSimpleFoam.C
@@ -154,7 +154,7 @@ void DAResidualRhoSimpleFoam::calcResiduals(const dictionary& options)
 
     // ******** e Residuals **********
     // copied and modified from EEqn.H
-    volScalarField alphaEff("alphaEff", thermo_.alphaEff(rho_ * alphat_));
+    volScalarField alphaEff("alphaEff", thermo_.alphaEff(alphat_));
 
     fvSourceEnergy_ = fvSource_ & U_;
 

--- a/src/adjoint/DAResidual/DAResidualSonicFoam.C
+++ b/src/adjoint/DAResidual/DAResidualSonicFoam.C
@@ -106,7 +106,7 @@ void DAResidualSonicFoam::calcResiduals(const dictionary& options)
     // Get a reference to thermo's internal energy field
     volScalarField& e = thermo_.he();
     
-    volScalarField alphaEff("alphaEff", thermo_.alphaEff(rho_ * alphat_));
+    volScalarField alphaEff("alphaEff", thermo_.alphaEff(alphat_));
 
     fvScalarMatrix eEqn(
         fvm::ddt(rho_, e)
@@ -296,7 +296,7 @@ void DAResidualSonicFoam::calcPCMatWithFvMatrix(Mat PCMat)
     UEqn.relax();
 
     // ******** T Residuals (from energy equation) **********
-    volScalarField alphaEff("alphaEff", thermo_.alphaEff(rho_ * alphat_));
+    volScalarField alphaEff("alphaEff", thermo_.alphaEff(alphat_));
 
     // Get reference to thermo's internal energy
     volScalarField& e = thermo_.he();

--- a/src/adjoint/DAResidual/DAResidualTurboFoam.C
+++ b/src/adjoint/DAResidual/DAResidualTurboFoam.C
@@ -131,7 +131,7 @@ void DAResidualTurboFoam::calcResiduals(const dictionary& options)
     // ******** e Residuals **********
     // copied and modified from EEqn.H
     volSymmTensorField Teff = -daTurb_.devRhoReff();
-    volScalarField alphaEff("alphaEff", thermo_.alphaEff(rho_ * alphat_));
+    volScalarField alphaEff("alphaEff", thermo_.alphaEff(alphat_));
 
     URel_ == U_;
     MRF_.makeRelative(URel_);

--- a/src/adjoint/DASolver/DASonicFoam/createFieldsSonic.H
+++ b/src/adjoint/DASolver/DASonicFoam/createFieldsSonic.H
@@ -41,7 +41,15 @@ rhoPtr_.reset(
             mesh,
             IOobject::NO_READ,
             IOobject::AUTO_WRITE),
-        thermo.rho()));
+        // thermo.rho() in sonicFoam may return a field without mass-density
+        // dimensions, which later causes dimension mismatches when forming
+        // dynamic diffusivity terms like rho*alphat. Attach the correct
+        // density dimensions while preserving the numerical values.
+        thermo.rho()
+        * dimensionedScalar(
+              "rhoDim",
+              dimensionSet(1, -3, 0, 0, 0, 0, 0),
+              1.0)));
 volScalarField& rho = rhoPtr_();
 
 // Sync thermo's T with our T field

--- a/src/adjoint/DASolver/DASonicFoam/pEqnSonic.H
+++ b/src/adjoint/DASolver/DASonicFoam/pEqnSonic.H
@@ -1,4 +1,10 @@
-rho = thermo.rho();
+// thermo.rho() may lack mass-density dimensions; reattach them to avoid
+// dimension-set inconsistencies in subsequent operations.
+rho = thermo.rho()
+    * dimensionedScalar(
+          "rhoDim",
+          dimensionSet(1, -3, 0, 0, 0, 0, 0),
+          1.0);
 
 volScalarField rAU(1.0/UEqn.A());
 surfaceScalarField rhorAUf("rhorAUf", fvc::interpolate(rho*rAU));
@@ -43,5 +49,10 @@ U.correctBoundaryConditions();
 fvOptions.correct(U);
 K = 0.5*magSqr(U);
 
-rho = thermo.rho();
+// Keep rho field's physical dimensions consistent after each update
+rho = thermo.rho()
+    * dimensionedScalar(
+          "rhoDim",
+          dimensionSet(1, -3, 0, 0, 0, 0, 0),
+          1.0);
 DAUtility::boundVar(allOptions, rho, pimplePrintToScreen);


### PR DESCRIPTION
## Summary
- Ensure density field carries mass-density dimensions when created and updated
- Pass kinematic turbulent diffusivity to `thermo.alphaEff` and update residuals to avoid dimension mismatches

## Testing
- `python3 Cylinder/runScript.py -task run_model -optimizer IPOPT` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*
- `wmake src/adjoint` *(fails: command not found: wmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b32290ba88832aad5f22ae2b8d202b